### PR TITLE
WIP: use PooledArray for strings by default

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.5
 NullableArrays
+PooledArrays
+WeakRefStrings
 QuickTypes

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -187,7 +187,8 @@ end
 
 function makeoutputvecs(str, rec, N)
     ([if fieldtype(f) == StrRange
-        Array{String,1}(N)
+      # By default we put strings in a PooledArray
+      resize!(PooledArray(Int32[], String[]), N)
     elseif fieldtype(f) == Nullable{StrRange}
         NullableArray{String}(N)
     elseif fieldtype(f) <: Nullable

--- a/src/field.jl
+++ b/src/field.jl
@@ -116,20 +116,11 @@ end
 #     vec = Vector{UInt8}(str)
 #     WeakRefString(pointer(vec)+(i-1), (j-i+1))
 # end
-
-# StrRange
-# This type is the beginning of a hack to avoid allocating 3 objects
-# instead of just 1 when using the `tryparsenext` framework.
-# The expression (Nullable{String}("xyz"), 4) asks the GC to track
-# the string, the nullable and the tuple. Instead we return
-# (Nullable{StrRange}(StrRange(0,3)), 4) which makes 0 allocations.
-# later when assigning the column inside `tryparsesetindex` we
-# create the string. See `setcell!`
-immutable StrRange
-    offset::Int
-    length::Int
-end
 fromtype(::Type{StrRange}) = StringToken(StrRange)
+
+@inline function alloc_string(str, r::StrRange)
+    unsafe_string(pointer(str, 1+r.offset), r.length)
+end
 
 @inline function _substring(::Type{StrRange}, str, i, j)
     StrRange(i-1, j-i+1)

--- a/src/record.jl
+++ b/src/record.jl
@@ -56,8 +56,12 @@ end
     col[i] = val
 end
 
+@inline function setcell!{R}(col::PooledArray{String,R}, i, val::StrRange, str)
+    nonallocating_setindex!(col, i, val, str)
+end
+
 @inline function setcell!(col::Array{String,1}, i, val::StrRange, str)
-    col[i] = unsafe_string(pointer(str, 1+val.offset), val.length)
+    col[i] = alloc_string(str, val)
 end
 
 @inline function setcell!(col::NullableArray{String,1}, i, val::Nullable{StrRange}, str)


### PR DESCRIPTION
- [ ] fail and restart if too many uniques are found. (I'm thinking it's bad if uniques > 25% of the elements, I'm still unsure about how best to implement this however.)

reading a file with 1.48 million rows with one string column of all the same values:

Without this patch:
```
julia> @btime csvread("NZDUSD-2015-01.csv")
  512.684 ms (2939807 allocations: 220.05 MiB)
```

With:
```
julia> @btime csvread("NZDUSD-2015-01.csv")
  497.127 ms (7628 allocations: 55.57 MiB)
```

May have to benchmark with more files